### PR TITLE
Allow to use elixir v1.10

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule MixRebar3.MixProject do
     [
       app: :mix_rebar3,
       version: "0.1.0",
-      elixir: "~> 1.11",
+      elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       # Hex


### PR DESCRIPTION
I've tested with elixir version 1.10 and is working as expected.
The motivation behind this change is because this package is a dependency of `fs`, and is blocking it of being used with that elixir version.